### PR TITLE
Fix footer on schedule page to take up whole width 

### DIFF
--- a/schedule.html
+++ b/schedule.html
@@ -91,7 +91,6 @@
     </nav>
   </header>
 
-
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-10">
@@ -100,44 +99,46 @@
     </div>
   </div>
 
-    <ul class="nav justify-content-center conference-days">
-      <li class="nav-item">
-        <a class="nav-link active" href="#friday">Friday</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="#saturday">Saturday</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="#sunday">Sunday</a>
-      </li>
-    </ul>
+  <ul class="nav justify-content-center conference-days">
+    <li class="nav-item">
+      <a class="nav-link active" href="#friday">Friday</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#saturday">Saturday</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="#sunday">Sunday</a>
+    </li>
+  </ul>
 
   <!-- Friday Start -->
 
   <div class="container-fluid conference-schedule" id="friday">
     <div class="row justify-content-center">
-      <div class="col">
-          <h3>Resume Clinic</h3>
-          <h5>Friday, June 7, 2019</h5>
-          <h5>4:00 - 8:00 PM</h5>
-          <p>More details to come.</p>
-      </div>
+        <div class="col">
+            <h3>Resume Clinic</h3>
+            <h5>Friday, June 7, 2019</h5>
+            <h5>4:00 - 8:00 PM</h5>
+            <p>More details to come.</p>
+        </div>
     </div>
+  </div>
 
   <!-- Saturday Start -->
   <div class="container-fluid conference-schedule" id="saturday">
-    <div class="row">
-      <div class="col ">
+    <div class="row justify-content-center">
+        <div class="col">
           <h3>Workshops | Unconference | Career & Community Fair | Coaching Mini Sessions</h3>
           <h5>Saturday, June 8, 2019</h5>
           <h5>9:00 AM - 5:00 PM</h5>
           <p>More details to come.</p>
-      </div>
+        </div>
     </div>
+  </div>
 
   <!-- Sunday Start -->
   <div class="container-fluid conference-schedule" id="sunday">
-    <div class="row">
+    <div class="row justify-content-center">
       <div class="col">
           <h3>Workshops | Unconference | Career & Community Fair | Coaching Mini Sessions</h3>
           <h5>Sunday, June 9, 2019</h5>
@@ -145,14 +146,12 @@
           <p>More details to come.</p>
       </div>
     </div>
+  </div>
 
   <div class="container">
     <div class="row justify-content-center">
-      <div class="col-10">
-
-        <div class="col-4 mx-auto">
-          <img src="assets/shes-coding-space-cat.png" class="img-fluid" alt="Tech Women Rising Conference Mascot">
-        </div>
+      <div class="col-4 mx-auto">
+        <img src="assets/shes-coding-space-cat.png" class="img-fluid" alt="Tech Women Rising Conference Mascot">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Footer on schedule page is off http://techwomenrising.org/schedule.html : doesn't take up whole width the way it does on the homepage. Reason: missing closing `</div>` tags. Added missing tags to fix the layout render.
