### PR TITLE
Fix menu overlap, add UI color blocks for homepage to improve user experience

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -193,7 +193,7 @@
 
     <div class="container" id="cta">
       <div class="row justify-content-center">
-        <a class="btn btn-outline-primary btn-lg" href="https://impactflow.com/event/6323/checkout/tickets">Get Your Tickets Today!</a>
+        <button class="btn btn-primary btn-lg" href="#" role="button" disabled>Tickets Coming Soon!</button>
       </div>
     </div>
 

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -59,11 +59,11 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Events</a>
                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                 <a class="dropdown-item" href="career-and-community-fair.html">Career & Community Fair</a>
-                 <a class="dropdown-item" href="index.html#resume-clinic">Resume Clinic</a>
-                 <a class="dropdown-item" href="workshops.html">Workshops</a>
-                 <a class="dropdown-item" href="coaching-mini-sessions.html">Coaching Mini Sessions</a>
-                 <a class="dropdown-item" href="unconference.html">Unconference</a>
+                <a class="dropdown-item" href="index.html#career-and-community-fair">Career & Community Fair</a>
+                <a class="dropdown-item" href="index.html#resume-clinic">Resume Clinic</a>
+                <a class="dropdown-item" href="index.html#workshops">Workshops</a>
+                <a class="dropdown-item" href="index.html#coaching-mini-sessions">Coaching Mini Sessions</a>
+                <a class="dropdown-item" href="index.html#unconference">Unconference</a>
                </div>
             </li>
             <li class="nav-item">

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -193,7 +193,8 @@
 
     <div class="container" id="cta">
       <div class="row justify-content-center">
-        <button class="btn btn-primary btn-lg" href="#" role="button" disabled>Tickets Coming Soon!</button>
+        <button class="btn btn-primary btn-lg" href="#" role="button" disabled style="white-space:normal !important;
+        word-wrap: break-word;">Tickets Coming Soon!</button>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
     </header>
 
     <div class="jumbotron" id="home">
-      <div class="container">
+      <div class="container-fluid mt-5">
         <div class="row justify-content-center">
           <div class="col-10 highlight">
             <h1>Tech Women Rising 2019</h1>
@@ -101,29 +101,32 @@
       </div>
     </div>
 
-    <div class="container" id="about">
-      <div class="row justify-content-center">
-        <div class="col-10">
-
-          <div class="col-3 mx-auto">
+    <div class="container-fluid pt-5 pb-5" id="about">
+      <div class="row justify-content-center pt-5">
+          <div class="col-3 col-offset-1">
             <img src="assets/shes-coding-space-cat.png" class="img-fluid" alt="Tech Women Rising Conference Mascot">
           </div>
-          <h2>Tech Women Rising</h2>
-          <h3>Standing Together. Growing Together. Rising Together.</h3>
-          <p>Join your peers, reach for your goals, spend an invigorating weekend with fellow women in tech! Tech Women Rising is She's Coding's annual conference, happening in June 2019 at Flatiron School in Downtown Seattle, WA.</p>
-          <p>Technical women of all levels and backgrounds - join us when we meet at Tech Women Rising to learn, share, and grow together. Tech Women Rising is not your typical tech conference! We combine multiple parts into one event: workshops meant to teach and empower; a career & community fair meant to connect and build bridges; an unconference meant to inspire, support & grow a community; a resume clinic and mini coaching sessions meant to advance your career.</p>
-          <p>The event will be open to women and people of diverse gender.</p>
+          <div class="col-7">
+              <h2 class="m-0 p-0">Tech Women Rising</h2>
+              <h3>Standing Together.</h3>
+              <h3>Growing Together.</h3>
+              <h3>Rising Together.</h3>
+          </div>
+          <div class="col-10">
+              <p>Join your peers, reach for your goals, spend an invigorating weekend with fellow women in tech! Tech Women Rising is She's Coding's annual conference, happening in June 2019 at Flatiron School in Downtown Seattle, WA.</p>
+              <p>Technical women of all levels and backgrounds - join us when we meet at Tech Women Rising to learn, share, and grow together. Tech Women Rising is not your typical tech conference! We combine multiple parts into one event: workshops meant to teach and empower; a career & community fair meant to connect and build bridges; an unconference meant to inspire, support & grow a community; a resume clinic and mini coaching sessions meant to advance your career.</p>
+              <p>The event will be open to women and people of diverse gender.</p>
+          </div>
         </div>
-      </div>
     </div>
 
-    <div class="container-fluid mailing-list">
+    <div class="container-fluid mailing-list-blue pt-5 pb-5">
       <div class="row justify-content-center">
         <div class="col">
           <h3>Join our mailing list and get a reminder to join Tech Women Rising in June 2019!</h3>
 
           <!-- Begin MailChimp Signup Form -->
-          <div id="mc_embed_signup_scroll" class="d-flex justify-content-center">
+          <div id="mc_embed_signup_scroll" class="pb-3 d-flex justify-content-center">
 
             <form action="https://shescoding.us13.list-manage.com/subscribe/post?u=2c06e9aeddb5548a94e22590c&amp;id=2980c926be" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate form-inline" target="_blank" novalidate>
 
@@ -148,7 +151,7 @@
       </div>
     </div>
 
-    <div class="container" id="career-and-community-fair">
+    <div class="container-fluid pt-5 pb-5" id="career-and-community-fair">
       <div class="row justify-content-center">
         <div class="col-10">
           <h2>Career & Community Fair</h2>
@@ -159,7 +162,7 @@
       </div>
     </div>
 
-    <div class="container" id="resume-clinic">
+    <div class="container-fluid grey-section pt-5 pb-5" id="resume-clinic">
       <div class="row justify-content-center">
         <div class="col-10">
           <h2>Resume Clinic</h2>
@@ -170,7 +173,7 @@
       </div>
     </div>
 
-    <div class="container" id="workshops">
+    <div class="container-fluid pt-5 pb-5" id="workshops">
       <div class="row justify-content-center">
         <div class="col-10">
           <h2>Workshops</h2>
@@ -182,7 +185,7 @@
       </div>
     </div>
 
-    <div class="container" id="coaching-mini-sessions">
+    <div class="container-fluid grey-section pt-5 pb-5" id="coaching-mini-sessions">
       <div class="row justify-content-center">
         <div class="col-10">
           <h2>Coaching Mini Sessions</h2>
@@ -193,7 +196,7 @@
       </div>
     </div>
 
-    <div class="container" id="unconference">
+    <div class="container-fluid pt-5 pb-5" id="unconference">
       <div class="row justify-content-center">
         <div class="col-10">
           <h2>Unconference</h2>
@@ -205,7 +208,7 @@
     </div>
 
     <div id="sponsors-and-partners">
-      <div class="container">
+      <div class="container-fluid super-light-blue-section pt-5 pb-5">
         <div class="row justify-content-center">
           <div class="col-10">
             <h2>Sponsors & Partners</h2>
@@ -213,70 +216,62 @@
             <p>Check out our sponsors & partners from <a href="2018/index.html#sponsors-and-partners" target="blank">Tech Women Rising 2018</a> - why don't you join us this year?</p>
           </div>
         </div>
-      </div>
-
-      <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-10">
-
-              <div class="row justify-content-center">
-                <div class="col">
-                  <h3>Sponsors</h3>
-                  <!-- <div class="col-4">
-                    <p>Keep a lookout for more coming...</p>
-                  </div> -->
-                </div>
-              </div>
-
-              <div class="row justify-content-center">
-                <div class="col">
-                  <h4>Venue Sponsors</h4>
-                </div>
-              </div>
-              <div class="row justify-content-center">
+        <!-- <div class="row justify-content-center">
+          <div class="col-10">
+            <div class="row justify-content-center">
+              <div class="col">
+                <h3>Sponsors</h3>
                 <div class="col-4">
-                  <a href="https://flatironschool.com/campuses/seattle/" target="_blank"><img src="assets/sponsors/flatiron-school-logo.png" class="img-fluid" alt="Flatiron School Logo"></a>
-                </div>
-                <div class="col-4">
-                  <a href="https://www.wework.com/labs" target="_blank"><img src="assets/sponsors/wework-labs-logo.png" class="img-fluid" alt="WeWork Labs Logo"></a>
+                  <p>Keep a lookout for more coming...</p>
                 </div>
               </div>
+            </div>
+          </div>
+        </div> -->
+        <div class="row justify-content-center mb-3 mt-3 light-blue-section">
+          <div class="col">
+            <h4 class="no-border p-3">Venue Sponsors</h4>
+          </div>
+        </div>
+        <div class="row justify-content-center pt-5">
+          <div class="col-4">
+            <a href="https://flatironschool.com/campuses/seattle/" target="_blank"><img src="assets/sponsors/flatiron-school-logo.png" class="img-fluid" alt="Flatiron School Logo"></a>
+          </div>
+          <div class="col-4">
+            <a href="https://www.wework.com/labs" target="_blank"><img src="assets/sponsors/wework-labs-logo.png" class="img-fluid" alt="WeWork Labs Logo"></a>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="container">
+    <div class="container-fluid grey-section pt-5">
       <div class="row justify-content-center">
         <div class="col-10">
           <h2>Location</h2>
         </div>
       </div>
-    </div>
-
-    <div class="container-fluid" id="map">
-      <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2689.866812733109!2d-122.33855398391073!3d47.60927939578521!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54906b94a88d92d9%3A0x375ae7872dd83563!2sFlatiron+School!5e0!3m2!1sen!2sus!4v1539152399929" width="100%" height="600" frameborder="0" style="border:0" allowfullscreen></iframe>
-      <div class="map-address">
-        <address>1411 4th Ave, Seattle, WA 98101</address>
-      </div>
-    </div>
-
-    <div class="container" id="organizer">
-      <div class="row justify-content-center">
-        <div class="col-10">
-          <h2>Organizer & Organizing Team</h2>
-          <div class="col-7 mx-auto">
-            <a href="http://shescoding.org"><img src="assets/shescoding-logo.png" class="img-fluid" alt="She's Coding Logo"></a>
-          </div>
-          <div class="col-8 mx-auto">
-            <p>She’s Coding is a WA charity with the main goal to help close the gender gap in tech. We operate on three main pillars: (1) An open-source website that educates women, allies and companies about the gender gap, developed in mentorship-based volunteer groups. (2) A mentorship program, as well as an offline and online safe community for women in tech. And (3), support for women in their tech industry job searches via events, collaborations, and a yearly conference with career fair and workshops.</p>
-            <p>Want to volunteer and work with us to make Tech Women Rising 2019 the best event it can be? <a href="mailto:techwomenrising@shescoding.org" target="blank">Contact us</a> - we're looking forward to chat with you!</p>
-          </div>
+      <div id="map">
+        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2689.866812733109!2d-122.33855398391073!3d47.60927939578521!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54906b94a88d92d9%3A0x375ae7872dd83563!2sFlatiron+School!5e0!3m2!1sen!2sus!4v1539152399929" width="100%" height="600" frameborder="0" style="border:0" allowfullscreen></iframe>
+        <div class="map-address">
+          <address>1411 4th Ave, Seattle, WA 98101</address>
         </div>
       </div>
     </div>
 
-    <div class="container">
+    <div class="container-fluid pt-5 pb-5" id="organizer">
+      <div class="row justify-content-center">
+        <div class="col-10">
+          <h2>Organizer & Organizing Team</h2>
+            <div class="text-center mb-3">
+              <a href="http://shescoding.org"><img src="assets/shescoding-logo.png" class="img-fluid" alt="She's Coding Logo"></a>
+            </div>
+            <p>She’s Coding is a WA charity with the main goal to help close the gender gap in tech. We operate on three main pillars: (1) An open-source website that educates women, allies and companies about the gender gap, developed in mentorship-based volunteer groups. (2) A mentorship program, as well as an offline and online safe community for women in tech. And (3), support for women in their tech industry job searches via events, collaborations, and a yearly conference with career fair and workshops.</p>
+            <p>Want to volunteer and work with us to make Tech Women Rising 2019 the best event it can be? <a href="mailto:techwomenrising@shescoding.org" target="blank">Contact us</a> - we're looking forward to chat with you!</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid pb-5">
       <div class="row justify-content-center">
         <div class="col-3">
           <figure>
@@ -288,13 +283,13 @@
       </div>
     </div>
 
-    <div class="container-fluid mailing-list">
+    <div class="container-fluid mailing-list-blue pt-5 pb-5">
       <div class="row justify-content-center">
         <div class="col">
           <h3>Join our mailing list!</h3>
 
           <!-- Begin MailChimp Signup Form -->
-          <div id="mc_embed_signup_scroll" class="d-flex justify-content-center">
+          <div id="mc_embed_signup_scroll" class="pb-3 d-flex justify-content-center">
 
             <form action="https://shescoding.us13.list-manage.com/subscribe/post?u=2c06e9aeddb5548a94e22590c&amp;id=2980c926be" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate form-inline" target="_blank" novalidate>
 
@@ -323,7 +318,7 @@
         <div class='scroll icon'><i class="fa fa-2x fa-angle-up"></i></div>
     </div>
 
-    <footer class="">
+    <footer>
       <div class="container-fluid">
         <div class="row d-flex justify-content-center">
           <a href="https://www.facebook.com/shescoding"><i class="fab fa-facebook-square fa-2x"></i></a>

--- a/index.html
+++ b/index.html
@@ -95,7 +95,8 @@
             <h1>Tech Women Rising 2019</h1>
             <p class="event-dates">Friday, <time datetime="2019-06-07">June 7, 2019</time> - Sunday, <time datetime="2019-06-09">June 9, 2019</time></p>
             <address>Flatiron School, 1411 4th Ave, Seattle, WA 98101</address>
-            <button class="btn btn-primary btn-lg" href="#" role="button" disabled>Tickets Coming Soon!</button>
+            <button class="btn btn-primary btn-lg" href="#" role="button" disabled style="white-space:normal !important;
+            word-wrap: break-word;">Tickets Coming Soon!</button>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -61,11 +61,11 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Content</a>
                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                 <a class="dropdown-item" href="#career-and-community-fair">Career & Community Fair</a>
-                 <a class="dropdown-item" href="#resume-clinic">Resume Clinic</a>
-                 <a class="dropdown-item" href="#workshops">Workshops</a>
-                 <a class="dropdown-item" href="#coaching-mini-sessions">Coaching Mini Sessions</a>
-                 <a class="dropdown-item" href="#unconference">Unconference</a>
+                 <a class="dropdown-item" href="index.html#career-and-community-fair">Career & Community Fair</a>
+                 <a class="dropdown-item" href="index.html#resume-clinic">Resume Clinic</a>
+                 <a class="dropdown-item" href="index.html#workshops">Workshops</a>
+                 <a class="dropdown-item" href="index.html#coaching-mini-sessions">Coaching Mini Sessions</a>
+                 <a class="dropdown-item" href="index.html#unconference">Unconference</a>
                </div>
             </li>
             <li class="nav-item">
@@ -95,14 +95,14 @@
             <h1>Tech Women Rising 2019</h1>
             <p class="event-dates">Friday, <time datetime="2019-06-07">June 7, 2019</time> - Sunday, <time datetime="2019-06-09">June 9, 2019</time></p>
             <address>Flatiron School, 1411 4th Ave, Seattle, WA 98101</address>
-            <a class="btn btn-primary btn-lg" href="#" role="button">Tickets Coming Soon!</a>
+            <button class="btn btn-primary btn-lg" href="#" role="button" disabled>Tickets Coming Soon!</button>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="container-fluid pt-5 pb-5" id="about">
-      <div class="row justify-content-center pt-5">
+    <div class="container-fluid pt-5 pb-3" id="about">
+      <div class="row justify-content-center pt-3">
           <div class="col-3 col-offset-1">
             <img src="assets/shes-coding-space-cat.png" class="img-fluid" alt="Tech Women Rising Conference Mascot">
           </div>

--- a/index.html
+++ b/index.html
@@ -104,10 +104,10 @@
 
     <div class="container-fluid pt-5 pb-3" id="about">
       <div class="row justify-content-center pt-3">
-          <div class="col-3 col-offset-1">
+          <div class="col-2 col-offset-1">
             <img src="assets/shes-coding-space-cat.png" class="img-fluid" alt="Tech Women Rising Conference Mascot">
           </div>
-          <div class="col-7">
+          <div class="col-4">
               <h2 class="m-0 p-0">Tech Women Rising</h2>
               <h3>Standing Together.</h3>
               <h3>Growing Together.</h3>
@@ -121,7 +121,7 @@
         </div>
     </div>
 
-    <div class="container-fluid mailing-list-blue pt-5 pb-5">
+    <div class="container-fluid mailing-list-grey pt-5 pb-5">
       <div class="row justify-content-center">
         <div class="col">
           <h3>Join our mailing list and get a reminder to join Tech Women Rising in June 2019!</h3>
@@ -209,7 +209,7 @@
     </div>
 
     <div id="sponsors-and-partners">
-      <div class="container-fluid super-light-blue-section pt-5 pb-5">
+      <div class="container-fluid grey-section pt-5 pb-5">
         <div class="row justify-content-center">
           <div class="col-10">
             <h2>Sponsors & Partners</h2>
@@ -229,7 +229,7 @@
             </div>
           </div>
         </div> -->
-        <div class="row justify-content-center mb-3 mt-3 light-blue-section">
+        <div class="row justify-content-center mb-3 mt-3 grey-section">
           <div class="col">
             <h4 class="no-border p-3">Venue Sponsors</h4>
           </div>
@@ -245,7 +245,7 @@
       </div>
     </div>
 
-    <div class="container-fluid grey-section pt-5">
+    <div class="container-fluid pt-5">
       <div class="row justify-content-center">
         <div class="col-10">
           <h2>Location</h2>
@@ -284,7 +284,7 @@
       </div>
     </div>
 
-    <div class="container-fluid mailing-list-blue pt-5 pb-5">
+    <div class="container-fluid mailing-list-grey pt-5 pb-5">
       <div class="row justify-content-center">
         <div class="col">
           <h3>Join our mailing list!</h3>

--- a/schedule.html
+++ b/schedule.html
@@ -64,11 +64,11 @@
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Content</a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <a class="dropdown-item" href="career-and-community-fair.html">Career & Community Fair</a>
+              <a class="dropdown-item" href="index.html#career-and-community-fair">Career & Community Fair</a>
               <a class="dropdown-item" href="index.html#resume-clinic">Resume Clinic</a>
-              <a class="dropdown-item" href="workshops.html">Workshops</a>
-              <a class="dropdown-item" href="coaching-mini-sessions.html">Coaching Mini Sessions</a>
-              <a class="dropdown-item" href="unconference.html">Unconference</a>
+              <a class="dropdown-item" href="index.html#workshops">Workshops</a>
+              <a class="dropdown-item" href="index.html#coaching-mini-sessions">Coaching Mini Sessions</a>
+              <a class="dropdown-item" href="index.html#unconference">Unconference</a>
             </div>
           </li>
           <li class="nav-item">

--- a/schedule.html
+++ b/schedule.html
@@ -97,23 +97,22 @@
         <h2>Conference Schedule</h2>
       </div>
     </div>
+    <ul class="nav justify-content-center conference-days ">
+      <li class="nav-item">
+        <a class="nav-link active" href="#friday">Friday</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#saturday">Saturday</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#sunday">Sunday</a>
+      </li>
+    </ul>
   </div>
-
-  <ul class="nav justify-content-center conference-days">
-    <li class="nav-item">
-      <a class="nav-link active" href="#friday">Friday</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#saturday">Saturday</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#sunday">Sunday</a>
-    </li>
-  </ul>
 
   <!-- Friday Start -->
 
-  <div class="container-fluid conference-schedule" id="friday">
+  <div class="container-fluid grey-section conference-schedule pt-0 pb-3" id="friday">
     <div class="row justify-content-center">
         <div class="col">
             <h3>Resume Clinic</h3>
@@ -125,7 +124,7 @@
   </div>
 
   <!-- Saturday Start -->
-  <div class="container-fluid conference-schedule" id="saturday">
+  <div class="container-fluid conference-schedule pt-0 pb-3" id="saturday">
     <div class="row justify-content-center">
         <div class="col">
           <h3>Workshops | Unconference | Career & Community Fair | Coaching Mini Sessions</h3>
@@ -137,7 +136,7 @@
   </div>
 
   <!-- Sunday Start -->
-  <div class="container-fluid conference-schedule" id="sunday">
+  <div class="container-fluid grey-section conference-schedule pt-0 pb-3" id="sunday">
     <div class="row justify-content-center">
       <div class="col">
           <h3>Workshops | Unconference | Career & Community Fair | Coaching Mini Sessions</h3>
@@ -158,7 +157,7 @@
 
   <div class="container" id="cta">
     <div class="row justify-content-center">
-      <a class="btn btn-outline-primary btn-lg" href="https://impactflow.com/event/6323/checkout/tickets">Get Your Tickets Today!</a>
+      <button class="btn btn-primary btn-lg" href="#" role="button" disabled>Tickets Coming Soon!</button>
     </div>
   </div>
 

--- a/schedule.html
+++ b/schedule.html
@@ -157,7 +157,8 @@
 
   <div class="container" id="cta">
     <div class="row justify-content-center">
-      <button class="btn btn-primary btn-lg" href="#" role="button" disabled>Tickets Coming Soon!</button>
+      <button class="btn btn-primary btn-lg" href="#" role="button" disabled style="white-space:normal !important;
+      word-wrap: break-word;">Tickets Coming Soon!</button>
     </div>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -116,18 +116,18 @@ input .btn .btn-primary:hover {
   background-color: #efefef;
   padding-bottom: 70px;
 }
-.mailing-list-blue {
-  background-color: #D0E1F9;
+.mailing-list-grey {
+  background-color: #efefef;
 }
-.mailing-list input, .mailing-list-blue input {
+.mailing-list input, .mailing-list-grey input {
   height: 48px;
   padding: 0.4em 0.8em;
 }
-.mailing-list input[type~="email"], .mailing-list-blue input[type~="email"]{
+.mailing-list input[type~="email"], .mailing-list-grey input[type~="email"]{
   width: 360px;
   margin-right: 10px;
 }
-.mailing-list input[type~="submit"], .mailing-list-blue input[type~="submit"] {
+.mailing-list input[type~="submit"], .mailing-list-grey input[type~="submit"] {
   text-transform: uppercase;
   font-weight: 600;
   letter-spacing: .03em;
@@ -273,16 +273,9 @@ img.padding-overall {
 }
 
 .grey-section {
-  background-color: #efefef;
+  background-color: #f8f8f8;
 }
 
-.super-light-blue-section {
-  background-color: #f0f6fd;
-}
-
-.light-blue-section {
-  background-color: #e7f0fc;
-}
 .no-border {
   border: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -58,7 +58,6 @@ h2 {
   color: #83c057;
   font-size: 2.4em;
   margin: 1em 0;
-  padding-top: 60px;
 }
 h3 {
   font-size: 1.2em;
@@ -83,7 +82,6 @@ nav {
 .navbar-brand {
   font-size:1.2em;
   font-weight: 600;
-  padding-left:15px;
 }
 
 .navbar-light .navbar-brand {
@@ -93,7 +91,7 @@ nav {
 li.nav-item {
   text-transform: uppercase;
   font-weight: 700;
-  padding: 15px;
+  padding: 5px;
 }
 .dropdown-item.active,
 .dropdown-item:active {
@@ -118,15 +116,18 @@ input .btn .btn-primary:hover {
   background-color: #efefef;
   padding-bottom: 70px;
 }
-.mailing-list input {
+.mailing-list-blue {
+  background-color: #D0E1F9;
+}
+.mailing-list input, .mailing-list-blue input {
   height: 48px;
   padding: 0.4em 0.8em;
 }
-.mailing-list input[type~="email"]{
+.mailing-list input[type~="email"], .mailing-list-blue input[type~="email"]{
   width: 360px;
   margin-right: 10px;
 }
-.mailing-list input[type~="submit"] {
+.mailing-list input[type~="submit"], .mailing-list-blue input[type~="submit"] {
   text-transform: uppercase;
   font-weight: 600;
   letter-spacing: .03em;
@@ -151,9 +152,6 @@ input .btn .btn-primary:hover {
   text-align: center;
   background-color: #efefef;
   padding: 30px;
-}
-#organizer p {
-  margin: 60px 0 30px;
 }
 figcaption {
   font-size: 1.2em;
@@ -272,4 +270,19 @@ img.padding-overall {
 .conference-schedule h5,
 .conference-schedule p {
   text-align: center;
+}
+
+.grey-section {
+  background-color: #efefef;
+}
+
+.super-light-blue-section {
+  background-color: #f0f6fd;
+}
+
+.light-blue-section {
+  background-color: #e7f0fc;
+}
+.no-border {
+  border: none;
 }


### PR DESCRIPTION
- to improve user experience this PR is suggesting color blocking different sections
- also makes nav fit 1 line to avoid content clashing

This is the homepage that this PR is suggesting (only css/ui changes, no content changes):
![conf-new-home](https://user-images.githubusercontent.com/18508181/49705058-e7c43e00-fbcf-11e8-93fb-343478641c02.png)

If this looks good, I would like to also update schedule page before deploy to have same color-block style.

